### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/Pure.Serialization.Json/Pure.Serialization.Json.csproj
+++ b/src/Pure.Serialization.Json/Pure.Serialization.Json.csproj
@@ -6,6 +6,8 @@
     <IsTrimmable>true</IsTrimmable>
     <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <!--<EnablePackageValidation>true</EnablePackageValidation>-->
+    <!--<PackageValidationBaselineVersion>x.x.x</PackageValidationBaselineVersion>-->
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Serialization.Json</PackageId>


### PR DESCRIPTION
Closes #37

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.